### PR TITLE
Add global rate limiting middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
+import { rateLimiter } from './middlewares/rate.limiter';
 import path from "path";
 dotenv.config();
 
@@ -18,6 +19,7 @@ app.use(morgan('dev'));
 app.use(helmet());
 app.use(cors());
 app.use(cookieParser());
+app.use(rateLimiter);
 
 app.use(express.json(), validateBody);
 

--- a/src/middlewares/rate.limiter.ts
+++ b/src/middlewares/rate.limiter.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface RateRecord {
+  count: number;
+  firstRequestTime: number;
+}
+
+const rateLimitWindowMs = 15 * 60 * 1000; // 15 minutes
+const maxRequests = 100;
+const ipStore = new Map<string, RateRecord>();
+
+export function rateLimiter(req: Request, res: Response, next: NextFunction) {
+  const ip = req.ip;
+  const now = Date.now();
+  const record = ipStore.get(ip);
+  if (!record || now - record.firstRequestTime > rateLimitWindowMs) {
+    ipStore.set(ip, { count: 1, firstRequestTime: now });
+    return next();
+  }
+  record.count += 1;
+  if (record.count > maxRequests) {
+    return res.status(429).json({ message: 'Too many requests, please try again later.' });
+  }
+  next();
+}


### PR DESCRIPTION
## Summary
- introduce custom rate limiter middleware
- apply the middleware to all routes in `app.ts`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2861a7848323b019291feba82e14